### PR TITLE
Works on python3

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,8 +14,8 @@ def on_connect(client, userdata, flags, rc):
 
 def on_message(client, userdata, msg):
     # The callback for when a PUBLISH message is received from the server.
-    print(msg.topic+" "+str(msg.payload))
-    if str(msg.payload) == "on":
+    print(msg.topic+" "+str(msg.payload, 'utf-8'))
+    if str(msg.payload, 'utf-8') == "on":
         subprocess.Popen(config.power_on_command,
                          shell=True, stdout=subprocess.PIPE)
     else:


### PR DESCRIPTION
encode string to avoid receiving b'off' instead of just off

## Description



## Related issues this fixes



## Checklist:

  - [x] Change is tested and works on my device.
  - [x] Linters have been run.
  - [x] Code is ready for merge (You can set the title to WIP to stop merge early)
